### PR TITLE
Remove info about Plug dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ def application do
 end
 ```
 
-and then run `$ mix deps.get`. Corsica is a plug and thus depends on
-[Plug][plug] too, but you have to explicitly list Plug as a dependency of your
-project (since the dependency is `optional: true` in Corsica).
+and then run `$ mix deps.get`.
 
 ## Overview
 


### PR DESCRIPTION
I think the docs should be update since `Plug` is no longer `optional: true` (see: https://github.com/whatyouhide/corsica/commit/01e6cee02a772c7478e0c8b9fc46a17dbf34d8c5 )