### PR TITLE
Require the :origins option to avoid the insecure "*" default

### DIFF
--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -67,7 +67,7 @@ defmodule Corsica do
   using a Corsica-based router or when plugging `Corsica` in a plug pipeline.
 
   `:origins` can be a single value or a list of values. `"*"` can only appear as
-  a single value. The default value is `"*"`.  The origin of a request
+  a single value. The default value is `[]`.  The origin of a request
   (specified by the `"origin"` request header) will be considered a valid origin
   if it "matches" at least one of the origins specified in `:origins`. What
   "matches" means depends on the type of origin. Origins can be:
@@ -266,7 +266,7 @@ defmodule Corsica do
     defstruct [
       :max_age,
       :expose_headers,
-      origins: "*",
+      origins: [],
       allow_methods: ~w(PUT PATCH DELETE),
       allow_headers: [],
       allow_credentials: false,

--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -281,7 +281,8 @@ defmodule Corsica do
   # Plug callbacks.
 
   def init(opts) do
-    sanitize_opts(opts)
+    opts
+    |> sanitize_opts
     |> require_origins
   end
 
@@ -310,15 +311,11 @@ defmodule Corsica do
     |> maybe_update_option(:expose_headers, &Enum.join(&1, ", "))
   end
 
-  defp require_origins(opts) do
-    cond do
-      opts.origins == nil ->
-        raise ArgumentError, message: "`:origins` option is required. It should a an array of domains or a string of a domain that you control. For example `origins: [\"https://app.example.com\", \"https://www.example.com\"]`. If you don't know which setting to use \"*\" will get you started, but it is VERY INSECURE. \"*\" completely disables all protections that CORS gives you, so you should never use \"*\" in a production environment. For more details see https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing"
-      true ->
-        opts
-    end
-
+  defp require_origins(%Options{origins: nil}) do
+    raise ArgumentError, message: "`:origins` option is required. It should a an array of domains or a string of a domain that you control. For example `origins: [\"https://app.example.com\", \"https://www.example.com\"]`. If you don't know which setting to use \"*\" will get you started, but it is VERY INSECURE. \"*\" completely disables all protections that CORS gives you, so you should never use \"*\" in a production environment. For more details see https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing"
   end
+
+  defp require_origins(opts), do: opts
 
   defp maybe_update_option(opts, option, update_fun) do
     if value = Map.get(opts, option) do

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -35,6 +35,17 @@ defmodule CorsicaTest do
            |> preflight_req?()
   end
 
+  describe "init/1" do
+    test "raises an ArgumentError if :origins is not set" do
+      assert_raise ArgumentError, ~r/required/, fn ->
+        init([])
+      end
+    end
+    test "does not raises an ArgumentError if :origins is set" do
+      init(origins: "https://example.com")
+    end
+  end
+
   describe "sanitize_opts/1" do
     test ":max_age" do
       assert sanitize_opts(max_age: 600).max_age == "600"
@@ -50,7 +61,9 @@ defmodule CorsicaTest do
       assert sanitize_opts(origins: ["foo.bar", ~r/.*/, {MyMod, :my_fun}]).origins ==
                ["foo.bar", ~r/.*/, {MyMod, :my_fun}]
 
-      assert sanitize_opts([]).origins == []
+      assert sanitize_opts([]).origins == nil
+      assert sanitize_opts(origins: "*").origins == "*"
+      assert sanitize_opts(origins: []).origins == []
     end
 
     test ":allow_methods" do

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -41,6 +41,11 @@ defmodule CorsicaTest do
         init([])
       end
     end
+    test "raises an ArgumentError if :origins is set to nil" do
+      assert_raise ArgumentError, ~r/required/, fn ->
+        init(origins: nil)
+      end
+    end
     test "does not raises an ArgumentError if :origins is set" do
       init(origins: "https://example.com")
     end

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -35,66 +35,59 @@ defmodule CorsicaTest do
            |> preflight_req?()
   end
 
-  describe "init/1" do
-    test "raises an ArgumentError if :origins is not set" do
-      assert_raise ArgumentError, ~r/required/, fn ->
-        init([])
-      end
-    end
-    test "raises an ArgumentError if :origins is set to nil" do
-      assert_raise ArgumentError, ~r/required/, fn ->
-        init(origins: nil)
-      end
-    end
-    test "does not raises an ArgumentError if :origins is set" do
-      init(origins: "https://example.com")
-    end
-  end
-
   describe "sanitize_opts/1" do
     test ":max_age" do
-      assert sanitize_opts(max_age: 600).max_age == "600"
-      assert sanitize_opts([]).max_age == nil
+      assert sanitize_opts(origins: "*", max_age: 600).max_age == "600"
+      assert sanitize_opts(origins: "*").max_age == nil
     end
 
     test ":expose_headers" do
-      assert sanitize_opts(expose_headers: ~w(X-Foo X-Bar)).expose_headers == "X-Foo, X-Bar"
-      assert sanitize_opts([]).expose_headers == nil
+      assert sanitize_opts(origins: "*", expose_headers: ~w(X-Foo X-Bar)).expose_headers ==
+               "X-Foo, X-Bar"
+
+      assert sanitize_opts(origins: "*").expose_headers == nil
     end
 
-    test ":origins" do
+    test ":origins is required" do
+      assert_raise ArgumentError, ~r/the :origins option is required/, fn ->
+        sanitize_opts([])
+      end
+    end
+
+    test "value of :origins" do
       assert sanitize_opts(origins: ["foo.bar", ~r/.*/, {MyMod, :my_fun}]).origins ==
                ["foo.bar", ~r/.*/, {MyMod, :my_fun}]
 
-      assert sanitize_opts([]).origins == nil
       assert sanitize_opts(origins: "*").origins == "*"
       assert sanitize_opts(origins: []).origins == []
     end
 
     test ":allow_methods" do
-      assert sanitize_opts(allow_methods: ~w(get pOSt PUT)).allow_methods == ~w(GET POST PUT)
-      assert sanitize_opts([]).allow_methods == ~w(PUT PATCH DELETE)
+      assert sanitize_opts(origins: "*", allow_methods: ~w(get pOSt PUT)).allow_methods ==
+               ~w(GET POST PUT)
+
+      assert sanitize_opts(origins: "*").allow_methods == ~w(PUT PATCH DELETE)
     end
 
     test ":allow_headers" do
-      assert sanitize_opts(allow_headers: ~w(X-Header y-HEADER)).allow_headers ==
+      assert sanitize_opts(origins: "*", allow_headers: ~w(X-Header y-HEADER)).allow_headers ==
                ~w(x-header y-header)
 
-      assert sanitize_opts([]).allow_headers == []
+      assert sanitize_opts(origins: "*").allow_headers == []
     end
 
     test ":allow_credentials" do
-      assert sanitize_opts(allow_credentials: true).allow_credentials == true
-      assert sanitize_opts([]).allow_credentials == false
+      assert sanitize_opts(origins: "*", allow_credentials: true).allow_credentials == true
+      assert sanitize_opts(origins: "*").allow_credentials == false
     end
 
     test ":log" do
-      log = sanitize_opts(log: [rejected: :error, accepted: false]).log
+      log = sanitize_opts(origins: "*", log: [rejected: :error, accepted: false]).log
       assert Keyword.fetch!(log, :rejected) == :error
       assert Keyword.fetch!(log, :invalid) == :debug
       assert Keyword.fetch!(log, :accepted) == false
 
-      assert sanitize_opts([]).log == false
+      assert sanitize_opts(origins: "*").log == false
     end
   end
 
@@ -133,19 +126,19 @@ defmodule CorsicaTest do
       conn = put_origin(conn(:get, "/"), "http://foo.com")
 
       conn = put_req_header(conn, "access-control-request-method", "PATCH")
-      assert allowed_preflight?(conn, sanitize_opts(allow_methods: ~w(PUT PATCH)))
-      assert allowed_preflight?(conn, sanitize_opts(allow_methods: ~w(patch)))
+      assert allowed_preflight?(conn, sanitize_opts(origins: "*", allow_methods: ~w(PUT PATCH)))
+      assert allowed_preflight?(conn, sanitize_opts(origins: "*", allow_methods: ~w(patch)))
 
-      opts = sanitize_opts(allow_methods: ~w(PATCH), allow_headers: ~w(X-Foo))
+      opts = sanitize_opts(origins: "*", allow_methods: ~w(PATCH), allow_headers: ~w(X-Foo))
       assert allowed_preflight?(conn, opts)
 
       # "Simple methods" are always allowed.
       conn = put_req_header(conn, "access-control-request-method", "POST")
-      assert allowed_preflight?(conn, sanitize_opts(allow_methods: ~w()))
+      assert allowed_preflight?(conn, sanitize_opts(origins: "*", allow_methods: ~w()))
 
       # When :allow_methods is :all all methods are allowed.
       conn = put_req_header(conn, "access-control-request-method", "WEIRDMETHOD")
-      assert allowed_preflight?(conn, sanitize_opts(allow_methods: :all))
+      assert allowed_preflight?(conn, sanitize_opts(origins: "*", allow_methods: :all))
     end
 
     test "with allowed requests (headers)" do
@@ -156,7 +149,7 @@ defmodule CorsicaTest do
         |> put_req_header("access-control-request-method", "PUT")
         |> put_req_header("access-control-request-headers", "X-Foo, X-Bar")
 
-      opts = sanitize_opts(allow_methods: ~w(PUT), allow_headers: ~w(X-Bar x-foo))
+      opts = sanitize_opts(origins: "*", allow_methods: ~w(PUT), allow_headers: ~w(X-Bar x-foo))
       assert allowed_preflight?(conn, opts)
 
       # "Simple headers" are always allowed.
@@ -165,7 +158,10 @@ defmodule CorsicaTest do
         |> put_req_header("access-control-request-method", "PUT")
         |> put_req_header("access-control-request-headers", "Accept, Content-Language")
 
-      assert allowed_preflight?(conn, sanitize_opts(allow_methods: ~w(PUT), allow_headers: ~w()))
+      assert allowed_preflight?(
+               conn,
+               sanitize_opts(origins: "*", allow_methods: ~w(PUT), allow_headers: ~w())
+             )
 
       # When :allow_headers is :all all headers are allowed.
       conn =
@@ -173,7 +169,10 @@ defmodule CorsicaTest do
         |> put_req_header("access-control-request-method", "PUT")
         |> put_req_header("access-control-request-headers", "X-Header, X-Other-Header")
 
-      assert allowed_preflight?(conn, sanitize_opts(allow_methods: ~w(PUT), allow_headers: :all))
+      assert allowed_preflight?(
+               conn,
+               sanitize_opts(origins: "*", allow_methods: ~w(PUT), allow_headers: :all)
+             )
     end
 
     test "with non-allowed requests" do
@@ -182,18 +181,18 @@ defmodule CorsicaTest do
         |> put_origin("http://foo.com")
         |> put_req_header("access-control-request-method", "OPTIONS")
 
-      refute allowed_preflight?(conn, sanitize_opts(allow_methods: ~w(PUT PATCH)))
-      refute allowed_preflight?(conn, sanitize_opts(allow_methods: ~w(put)))
+      refute allowed_preflight?(conn, sanitize_opts(origins: "*", allow_methods: ~w(PUT PATCH)))
+      refute allowed_preflight?(conn, sanitize_opts(origins: "*", allow_methods: ~w(put)))
 
-      opts = sanitize_opts(allow_methods: ~w(PUT), allow_headers: ~w(X-Foo))
+      opts = sanitize_opts(origins: "*", allow_methods: ~w(PUT), allow_headers: ~w(X-Foo))
       refute allowed_preflight?(conn, opts)
 
       conn = conn |> put_req_header("access-control-request-headers", "X-Foo, X-Bar")
 
-      opts = sanitize_opts(allow_methods: ~w(OPTIONS), allow_headers: ~w(X-Bar))
+      opts = sanitize_opts(origins: "*", allow_methods: ~w(OPTIONS), allow_headers: ~w(X-Bar))
       refute allowed_preflight?(conn, opts)
 
-      opts = sanitize_opts(allow_methods: ~w(OPTIONS), allow_headers: ~w(x-bar))
+      opts = sanitize_opts(origins: "*", allow_methods: ~w(OPTIONS), allow_headers: ~w(x-bar))
       refute allowed_preflight?(conn, opts)
     end
   end
@@ -281,7 +280,7 @@ defmodule CorsicaTest do
              end) =~ ~s(Simple CORS request from Origin "http://example.com" is not allowed)
 
       assert capture_log([level: :info], fn ->
-               put_cors_simple_resp_headers(conn(:get, "/"), log: [invalid: :info])
+               put_cors_simple_resp_headers(conn(:get, "/"), log: [invalid: :info], origins: "*")
              end) =~ ~s(Request is not a CORS request because there is no Origin header)
     end
   end
@@ -354,7 +353,7 @@ defmodule CorsicaTest do
 
     test "does nothing to non-CORS requests" do
       conn = conn(:options, "/")
-      assert conn == put_cors_preflight_resp_headers(conn, max_age: 1)
+      assert conn == put_cors_preflight_resp_headers(conn, origins: "*", max_age: 1)
     end
 
     test ":log option" do
@@ -369,7 +368,11 @@ defmodule CorsicaTest do
                conn(:options, "/")
                |> put_origin("http://example.com")
                |> put_req_header("access-control-request-method", "PUT")
-               |> put_cors_preflight_resp_headers(log: [rejected: :info], allow_methods: ["GET"], origins: "*")
+               |> put_cors_preflight_resp_headers(
+                    log: [rejected: :info],
+                    allow_methods: ["GET"],
+                    origins: "*"
+                  )
              end) =~
                ~s{Invalid preflight CORS request because the request method ("PUT") is not in :allow_methods}
 
@@ -382,7 +385,7 @@ defmodule CorsicaTest do
                     log: [rejected: :info],
                     allow_headers: ["x-nope"],
                     origins: "*"
-                 )
+                  )
              end) =~
                ~s{Invalid preflight CORS request because these headers were not allowed in :allow_headers: x-foo, x-bar}
 
@@ -399,7 +402,7 @@ defmodule CorsicaTest do
 
       assert capture_log([level: :info], fn ->
                conn(:options, "/")
-               |> put_cors_preflight_resp_headers(log: [invalid: :info])
+               |> put_cors_preflight_resp_headers(origins: "*", log: [invalid: :info])
              end) =~ ~s(Request is not a preflight CORS request)
     end
   end
@@ -424,7 +427,7 @@ defmodule CorsicaTest do
         conn(:options, "/")
         |> put_origin("http://example.com")
         |> put_req_header("access-control-request-method", "PUT")
-        |> send_preflight_resp(400, allow_methods: ~w(GET POST))
+        |> send_preflight_resp(400, origins: "*", allow_methods: ~w(GET POST))
 
       assert conn.state == :sent
       assert conn.status == 400
@@ -439,7 +442,7 @@ defmodule CorsicaTest do
     plug Corsica, allow_methods: ~w(PUT), origins: "*"
     plug :match
     plug :dispatch
-    match _, do: send_resp(conn, 200, "matched")
+    match(_, do: send_resp(conn, 200, "matched"))
   end
 
   test "using Corsica as a plug" do


### PR DESCRIPTION
~~Default to `[]` rather than `"*"`.
This reduces usability but increases security.~~

UPDATE: I have changed this PR to raise an `ArgumentError` if `:origins` is not specified. 