### PR TITLE
fix moduledoc for router

### DIFF
--- a/lib/corsica/router.ex
+++ b/lib/corsica/router.ex
@@ -25,7 +25,7 @@ defmodule Corsica.Router do
         use Corsica.Router,
           origins: ["http://foo.com", "http://bar.com"],
           allow_credentials: true,
-          max_age: 600,
+          max_age: 600
 
         resource "/*"
 


### PR DESCRIPTION
seems like a trailing comma in the moduledoc. just wanted to fix