### PR TITLE
fix match-all generation to get rid of compiler warning

### DIFF
--- a/lib/corsica/router.ex
+++ b/lib/corsica/router.ex
@@ -136,9 +136,13 @@ defmodule Corsica.Router do
         end
       end
 
-      # Match-all clause that just returns the connection unchanged.
-      match _ do
-        var!(conn)
+      has_match_all? = Enum.any?(routes, fn {r, _} -> r === "/*" end)
+
+      unless has_match_all? do
+        # Match-all clause that just returns the connection unchanged.
+        match _ do
+          var!(conn)
+        end
       end
     end
   end

--- a/lib/corsica/router.ex
+++ b/lib/corsica/router.ex
@@ -136,10 +136,10 @@ defmodule Corsica.Router do
         end
       end
 
-      has_match_all? = Enum.any?(routes, fn {r, _} -> r === "/*" end)
-
-      unless has_match_all? do
-        # Match-all clause that just returns the connection unchanged.
+      # If there is a match-all route like "/*", we don't do anything,
+      # otherwise we add a match-all clause that just returns the
+      # connection unchanged.
+      unless Enum.any?(routes, &match?({"/*", _opts}, &1)) do
         match _ do
           var!(conn)
         end

--- a/test/corsica/router_test.exs
+++ b/test/corsica/router_test.exs
@@ -2,6 +2,12 @@ defmodule Corsica.RouterTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  defmodule WildcardRouter do
+    use Corsica.Router, origins: "*", max_age: 600
+
+    resource "/*"
+  end
+
   defmodule MyRouter do
     use Corsica.Router, origins: "*", max_age: 600
 
@@ -36,6 +42,11 @@ defmodule Corsica.RouterTest do
     plug :dispatch
 
     get _, do: send_resp(conn, 200, "regex")
+  end
+
+  test "/foo on wildcard" do
+    conn = conn(:get, "/foo") |> put_origin("foo.com") |> WildcardRouter.call([])
+    assert get_resp_header(conn, "access-control-allow-origin") == ["*"]
   end
 
   test "/foo" do


### PR DESCRIPTION
@whatyouhide based on discussion on #36 , I am opening this PR.

closes #36 