### PR TITLE
Add `vary: origin` header when origin is "*"

### DIFF
--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -109,8 +109,9 @@ defmodule Corsica do
 
   ## The "vary" header
 
-  If `:origins` is any value that can match more than one origin (list, regex, or `"*"`),
-  then a `vary: origin` header is added to the response.
+  When Corsica is configured such that the `access-control-allow-origin` response
+  header will vary depending on the `origin` request header then a `vary: origin`
+  response header will be set.
 
   ## Options
 

--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -109,8 +109,8 @@ defmodule Corsica do
 
   ## The "vary" header
 
-  If `:origins` is a list with more than one value and the request origin
-  matches, then a `Vary: Origin` header is added to the response.
+  If `:origins` is any value that can match more than one origin (list, regex, or `"*"`),
+  then a `vary: origin` header is added to the response.
 
   ## Options
 
@@ -588,8 +588,8 @@ defmodule Corsica do
 
   # Only update the Vary header if the origin is not a binary (it could be a
   # regex or a function) or if there's a list of more than one origins.
-  defp update_vary_header(conn, origin) when is_binary(origin), do: conn
-  defp update_vary_header(conn, [origin]) when is_binary(origin), do: conn
+  defp update_vary_header(conn, origin) when is_binary(origin) and origin != "*", do: conn
+  defp update_vary_header(conn, [origin]) when is_binary(origin) and origin != "*", do: conn
 
   defp update_vary_header(conn, _origin),
     do: %{conn | resp_headers: [{"vary", "origin"} | conn.resp_headers]}

--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -585,8 +585,8 @@ defmodule Corsica do
     put_resp_header(conn, "access-control-allow-origin", value)
   end
 
-  # Add `vary: origin` response header if the `access-control-allow-origin` response header may
-  # have different values depending on the value of the `origin` request header.
+  # Add `vary: origin` response header if the `access-control-allow-origin` response header will
+  # vary depending on the `origin` request header.
   defp update_vary_header(conn, %Options{origins: [origin]} = opts) do
     update_vary_header(conn, %{opts | origins: origin})
   end

--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -574,8 +574,6 @@ defmodule Corsica do
   defp put_allow_origin_header(conn, %Options{} = opts) do
     [actual_origin | _] = get_req_header(conn, "origin")
 
-    # '*' cannot be used as the value of the `Access-Control-Allow-Origins`
-    # header if `Access-Control-Allow-Credentials` is true.
     value =
       if send_wildcard_origin?(opts) do
         "*"
@@ -601,6 +599,8 @@ defmodule Corsica do
   end
 
   defp send_wildcard_origin?(%Options{origins: origins, allow_credentials: allow_credentials}) do
+    # '*' cannot be used as the value of the `Access-Control-Allow-Origins`
+    # header if `Access-Control-Allow-Credentials` is true.
     origins == "*" and not allow_credentials
   end
 

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -245,13 +245,16 @@ defmodule CorsicaTest do
       conn = conn(:get, "/foo") |> put_origin("http://foo.com")
 
       new_conn = put_cors_simple_resp_headers(conn, origins: "*")
-      assert get_resp_header(new_conn, "vary") == ["origin"]
+      assert get_resp_header(new_conn, "vary") == []
 
       new_conn = put_cors_simple_resp_headers(conn, origins: "http://foo.com")
       assert get_resp_header(new_conn, "vary") == []
 
       new_conn = put_cors_simple_resp_headers(conn, origins: ["http://foo.com"])
       assert get_resp_header(new_conn, "vary") == []
+
+      new_conn = put_cors_simple_resp_headers(conn, allow_credentials: true, origins: "*")
+      assert get_resp_header(new_conn, "vary") == ["origin"]
 
       new_conn = put_cors_simple_resp_headers(conn, origins: ["http://foo.com", "http://bar.com"])
       assert get_resp_header(new_conn, "vary") == ["origin"]

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -245,7 +245,7 @@ defmodule CorsicaTest do
       conn = conn(:get, "/foo") |> put_origin("http://foo.com")
 
       new_conn = put_cors_simple_resp_headers(conn, origins: "*")
-      assert get_resp_header(new_conn, "vary") == []
+      assert get_resp_header(new_conn, "vary") == ["origin"]
 
       new_conn = put_cors_simple_resp_headers(conn, origins: "http://foo.com")
       assert get_resp_header(new_conn, "vary") == []


### PR DESCRIPTION
I ran into a bug with a caching proxy with the following configuration:

```elixir
config :my_app, :corsica,
  allow_credentials: true,
  origins: "*"
```

The response header `access-control-allow-origin` was being set to the actual origin due to this code:

https://github.com/whatyouhide/corsica/blob/02fd9302a5cd64abb50ba26089d0db8f8a0c5f66/lib/corsica.ex#L579-L586

This meant that the `access-control-allow-origin` response header varied depending on the `origin` request header. But the `vary: origin` response header wasn't being set. This pull-request fixes this.
