### PR TITLE
:log defaults to `[]`, use the default log levels

### DIFF
--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -202,7 +202,8 @@ defmodule Corsica do
   type completely. `false` can also be used as the value of the `:log` option
   directly to suppress all logs.
 
-  The default value for the `:log` option is `false`.
+  The default value for the `:log` option is `[]` (which means all is logged
+  according to the default log levels specified above).
 
   For example:
 
@@ -276,7 +277,7 @@ defmodule Corsica do
       allow_methods: ~w(PUT PATCH DELETE),
       allow_headers: [],
       allow_credentials: false,
-      log: false
+      log: []
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Corsica.Mixfile do
   use Mix.Project
 
-  @version "1.1.3"
+  @version "1.1.4"
 
   @description "Plug-based swiss-army knife for CORS requests."
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Corsica.Mixfile do
   use Mix.Project
 
-  @version "1.1.4"
+  @version "1.1.3"
 
   @description "Plug-based swiss-army knife for CORS requests."
 

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -89,11 +89,10 @@ defmodule CorsicaTest do
       assert Keyword.fetch!(log, :invalid) == :debug
       assert Keyword.fetch!(log, :accepted) == false
 
-      assert sanitize_opts(origins: "*").log == [
-               rejected: :warn,
-               invalid: :debug,
-               accepted: :debug
-             ]
+      log = sanitize_opts(origins: "*").log
+      assert Keyword.fetch!(log, :rejected) == :error
+      assert Keyword.fetch!(log, :invalid) == :debug
+      assert Keyword.fetch!(log, :accepted) == false
     end
   end
 

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -90,9 +90,9 @@ defmodule CorsicaTest do
       assert Keyword.fetch!(log, :accepted) == false
 
       log = sanitize_opts(origins: "*").log
-      assert Keyword.fetch!(log, :rejected) == :error
+      assert Keyword.fetch!(log, :rejected) == :warn
       assert Keyword.fetch!(log, :invalid) == :debug
-      assert Keyword.fetch!(log, :accepted) == false
+      assert Keyword.fetch!(log, :accepted) == :debug
     end
   end
 

--- a/test/corsica_test.exs
+++ b/test/corsica_test.exs
@@ -82,12 +82,18 @@ defmodule CorsicaTest do
     end
 
     test ":log" do
+      assert sanitize_opts(origins: "*", log: false).log == false
+
       log = sanitize_opts(origins: "*", log: [rejected: :error, accepted: false]).log
       assert Keyword.fetch!(log, :rejected) == :error
       assert Keyword.fetch!(log, :invalid) == :debug
       assert Keyword.fetch!(log, :accepted) == false
 
-      assert sanitize_opts(origins: "*").log == false
+      assert sanitize_opts(origins: "*").log == [
+               rejected: :warn,
+               invalid: :debug,
+               accepted: :debug
+             ]
     end
   end
 


### PR DESCRIPTION
Currently `:log` defaults to `:false`, which means nothing is logged. If something fails it will do it silently by default. When we as developers are integrating the `cors` support with Corsica for the first time, we expect an easy to integrate library. The problem is that sometimes there are some pitfalls that are making it very hard to get it work in the first run or event to diagnose it:

- Corsica will reject the preflight requests silently, it could be any of the reasons listed in [https://hexdocs.pm/corsica/common-issues.html](https://hexdocs.pm/corsica/common-issues.html), for example a missing `:allow_headers`, you need to dig deep into the library documentation to realize that.
- Chrome is not logging the OPTIONS requests anymore (you can activate a hidden flag inside the browser of course), bu it makes it tough to know which headers you actually need to allow.
- You could fail in specifying the correct order in the `:plugs` and you will not notice it.

Combine all these three and you will spend hours trying to make the `cors` support to work with this library.

One thing that will make it easier for the newcomers will be if everything is logged and such a cases are catch easily in the console. It will be more didactic in the sense that you will notice that the library is doing its job and that something else is actually failing. For the example above, not specifying the correct `allow_headers` will show this in the console:

![Screen Shot 2020-04-11 at 11 12 10 AM](https://user-images.githubusercontent.com/691521/79039975-56ab1000-7be5-11ea-88ba-3daeccc5f7e7.png)

I'm proposing an approach similar to Phoenix, which logs everything appropriately since the beginning, and it's flexible enough to configure it according to your needs later, when you focus on the deployment to production. But when you install a library in the development stage, your focus is to make it work first, later you can customize the logging according to your needs.