### PR TITLE
Pass the current connection to the tuple origin callbacks

### DIFF
--- a/lib/corsica.ex
+++ b/lib/corsica.ex
@@ -78,7 +78,7 @@ defmodule Corsica do
     * regexes - the actual origin has to match the allowed regex (as per
       `Regex.match?/2`)
     * `{module, function, args}` tuples - `module.function` is called with
-      2 extra arguments prepended to the given `args`: the actual origin
+      two extra arguments prepended to the given `args`: the actual origin
       and the current connection; if it returns `true` the origin is accepted,
       if it returns `false` the origin is not accepted
 


### PR DESCRIPTION
I have a case when `conn.assigns` carries the necessary information to later decide if the given origin accepted or not in a the tuple origin callback.

An alternative to the proposed patch could be changing `{module, function}` to `{module, function, args}`, but I'm not sure the `args` part is that useful given the static argument can be explicitly used in the callback function anyway.