### PR TITLE
Change version to 2.0 on README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the `:corsica` dependency to your project's `mix.exs`:
 defp deps do
   [
     {:plug, "~> 1.0"},
-    {:corsica, "~> 1.0"}
+    {:corsica, "~> 2.0"}
   ]
 end
 ```

--- a/test/readme_test.exs
+++ b/test/readme_test.exs
@@ -1,0 +1,11 @@
+defmodule ReadmeTest do
+  use ExUnit.Case, async: true
+
+  test "version in readme matches mix.exs" do
+    readme_markdown = File.read!(Path.join(__DIR__, "../README.md"))
+    mix_config = Mix.Project.config()
+    version = mix_config[:version]
+    [major_version | _] = String.split(version, ".")
+    assert readme_markdown =~ ~s({:corsica, "~> #{major_version}.0"})
+  end
+end


### PR DESCRIPTION
Change version to 2.0 on README installation section

Also add a test for README (!) checking that the version on README matches `mix.exs`, a [clever trick I saw on Twitter](https://twitter.com/royalicing/status/1687271985548820480/photo/1) posted by @royalicing.